### PR TITLE
Fix shipping service tracking ID letter generation

### DIFF
--- a/src/shippingservice/tracker.go
+++ b/src/shippingservice/tracker.go
@@ -42,7 +42,7 @@ func CreateTrackingId(salt string) string {
 
 // getRandomLetterCode generates a code point value for a capital letter.
 func getRandomLetterCode() uint32 {
-	return 65 + uint32(rand.Intn(25))
+	return 65 + uint32(rand.Intn(26))
 }
 
 // getRandomNumber generates a string representation of a number with the requested number of digits.

--- a/src/shippingservice/tracker_test.go
+++ b/src/shippingservice/tracker_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func TestGetRandomLetterCodeIncludesZ(t *testing.T) {
+	rand.Seed(1)
+	seenZ := false
+	for i := 0; i < 1000; i++ {
+		c := getRandomLetterCode()
+		if c < 65 || c > 90 {
+			t.Fatalf("generated code %d out of range", c)
+		}
+		if c == 90 {
+			seenZ = true
+			break
+		}
+	}
+	if !seenZ {
+		t.Errorf("did not generate letter code for Z within 1000 iterations")
+	}
+}


### PR DESCRIPTION
## Summary
- ensure random tracker letters can include Z
- add regression test for letter range

## Testing
- `go test ./...` *(fails: no route to host)*

------
https://chatgpt.com/codex/tasks/task_b_6858a81813a883218cfa56df41f0cebc